### PR TITLE
Fix react root hydration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,6 @@ import 'raf/polyfill';
 
 // Dependency libs
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { loadableReady } from '@loadable/component';
 
 // Import default styles before other CSS-related modules are imported
@@ -49,7 +48,7 @@ import { fetchCurrentUser } from './ducks/user.duck';
 import routeConfiguration from './routing/routeConfiguration';
 // App it self
 import { ClientApp, renderApp } from './app';
-import { createRoot } from 'react-dom/client';
+import { createRoot, hydrateRoot } from 'react-dom/client';
 
 const render = (store, shouldHydrate) => {
   // If the server already loaded the auth information, render the app
@@ -81,14 +80,14 @@ const render = (store, shouldHydrate) => {
         return { ...collectedData, [name]: content.data || {} };
       }, {});
 
+      const rootElement = document.getElementById('root');
       if (shouldHydrate) {
-        ReactDOM.hydrate(
-          <ClientApp store={store} hostedTranslations={translations} hostedConfig={hostedConfig} />,
-          document.getElementById('root')
+        hydrateRoot(
+          rootElement,
+          <ClientApp store={store} hostedTranslations={translations} hostedConfig={hostedConfig} />
         );
       } else {
-        const root = createRoot(document.getElementById('root'));
-        root.render(
+        createRoot(rootElement).render(
           <ClientApp store={store} hostedTranslations={translations} hostedConfig={hostedConfig} />
         );
       }


### PR DESCRIPTION
- Since we started using `createRoot` for client-side with React v18, we should be using `hydrateRoot` counterpart for server-side to avoid hydration issues.