### PR TITLE
Dev deploy v3

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,17 +1,2 @@
 REACT_APP_ENV=test
-
-# https://github.com/dilanx/craco/issues/522
-REACT_APP_ENV=false
-FAST_REFRESH=false
-
-# Environment variables for the client app.
-# THey need to be defined on BUILD time instead of RUNTIME (Server works with RUNTIME)
-# https://create-react-app.dev/docs/adding-custom-environment-variables
-REACT_APP_CSP=report
-REACT_APP_MAPBOX_ACCESS_TOKEN=pk.eyJ1IjoicmFmYWVsLXRoZWx1dXBlIiwiYSI6ImNsdzZvenBmZTJhZzcybHFzMXJpMDd0OXkifQ.4abt9M1UPVgb5afc1Cz9QQ
-REACT_APP_MARKETPLACE_NAME=The Luupe - QA
-REACT_APP_MARKETPLACE_ROOT_URL=https://market.qa.theluupe.com
-REACT_APP_SHARETRIBE_SDK_CLIENT_ID=198e4d3e-b64d-4e19-a503-8309affbbd5c
-REACT_APP_STRIPE_PUBLISHABLE_KEY=pk_test_51PGPLOFibVw716Tl9JCOjMHX5Py936BJbfkpiu2mjdcnMgtySmcEwVJMa2wF58GhKyV0bRVf6MKxIlFytF7Lrsmq00X3iAdO2i
-REACT_APP_MARKETPLACE_BRANDING_BUCKET=branding-dev.theluupe.com
-REACT_APP_TRANSLOADIT_SERVICE_URL=https://api2.transloadit.com
+# WE WON'T BE USING THIS ENV!!


### PR DESCRIPTION
Remove `test` ENV. From now on we will only use `development` and `production` given that we only have 2 environments inside our ecosystem 