### PR TITLE
Search filters fixes

### DIFF
--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -127,7 +127,7 @@ export class SearchPageComponent extends Component {
                 categoryIds: ['creatives'],
               },
               listingTypeConfig: {
-                limitToListingTypeIds: true,
+                limitToListingTypeIds: false,
                 listingTypeIds: ['profile-listing'],
               },
             },


### PR DESCRIPTION
Search Filters | Location filter should not be limited by listing type but instead by category alone