### PR TITLE
Claude Code init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,191 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+This is **TheLuupe Marketplace** — a heavily customized fork of [Sharetribe Web Template](https://github.com/sharetribe/web-template). It is a two-sided creative marketplace where photographers and creative professionals (sellers) list and sell digital assets, and buyers purchase or commission them. The upstream template handles core marketplace mechanics; TheLuupe adds its own transaction processes, integrations, and business logic on top.
+
+## Commands
+
+```bash
+# Development (runs frontend + backend concurrently)
+yarn dev
+
+# Run frontend only (port 3000)
+yarn dev-frontend
+
+# Run backend API server only (port 3500)
+yarn dev-backend
+
+# Build for production
+yarn build
+
+# Run all tests (server + client)
+yarn test-ci
+
+# Run only server-side tests
+yarn test-server
+
+# Run a single test file
+yarn test-server -- --testPathPattern=server/api-util/negotiation.test.js
+# OR for client tests:
+yarn test -- --testPathPattern=src/util/someFile.test.js
+
+# Lint / format
+yarn format        # auto-fix
+yarn format-ci     # check only (used in CI)
+
+# Check environment config before starting
+yarn config-check
+```
+
+Node version is managed via `.nvmrc` (currently `24.13.0`). Use `nvm use` before running anything.
+
+## Architecture overview
+
+### Dual-server model
+
+The app runs two separate Node processes in development:
+
+- **Frontend dev server** (`sharetribe-scripts start`) — Webpack + React, port 3000. Talks to Sharetribe's API via the SDK and proxies `/api/*` requests to the backend.
+- **Backend API server** (`server/apiServer.js`) — Express, port 3500. Handles everything that requires server-side credentials: Stripe, Google Cloud Storage, Auth0, Slack, Phototag, Voucherify, etc.
+
+In production, `server/index.js` serves both SSR rendering and the API routes on a single Express process.
+
+### Frontend structure
+
+```
+src/
+  containers/     # Page-level components, each with a .duck.js (Redux slice + loadData)
+  components/     # Shared reusable components
+  ducks/          # Global Redux slices (auth, marketplaceData, assets, etc.)
+  transactions/   # Transaction process graphs (one file per process)
+  routing/        # Route configuration — routeConfiguration.js is the master list
+  util/           # Pure utilities: api.js (all fetch calls), sdkLoader.js, etc.
+  translations/   # en.json (and de/es/fr) — local fallbacks; hosted translations override
+  config/         # configDefault.js — local fallbacks; hosted assets override
+```
+
+**Data flow:** Pages use `loadData` (in `.duck.js`) for SSR data fetching → Redux store → component. Never use `useEffect` for initial data loading; that pattern breaks SSR.
+
+**All client→server API calls** go through `src/util/api.js`. Add new calls there, not inline.
+
+### Backend structure
+
+```
+server/
+  api/              # Express route handlers (one file per concern)
+  api-util/         # Shared server utilities and third-party clients
+  api-util/transactions/  # Server-side transaction process definitions
+  scripts/events/   # Event-driven scripts triggered by Sharetribe webhooks
+  api/scripts-retry/      # Retry scripts for failed async operations
+```
+
+### Transaction processes
+
+Five processes, each defined in both frontend (`src/transactions/`) and backend (`server/api-util/transactions/`):
+
+| Process | File | When used |
+|---|---|---|
+| `default-purchase` | `transactionProcessPurchase.js` | Digital product checkout with Stripe |
+| `default-purchase-no-stripe` | `transactionProcessPurchaseNoStripe.js` | Off-platform payment |
+| `default-booking` | `transactionProcessBooking.js` | Time-based services |
+| `default-inquiry` | `transactionProcessInquiry.js` | Contact/inquiry flow |
+| `default-negotiation` | `transactionProcessNegotiation.js` | Offer/counter-offer flow |
+
+The negotiation process has two modes: **forward** (customer requests, provider offers) and **reverse** (provider lists an offer, customer responds). The listing's `publicData` determines which mode applies.
+
+> **Always ask for user approval before changing transaction processes**, and remind them that matching changes must be made to the Sharetribe backend via Console or the Integration API.
+
+### Key domain enums (`server/api-util/metadataHelper.js`)
+
+- **User types:** `buyer`, `creative-seller`, `studio-brand`
+- **Listing types:** `product-listing`, `hidden-product-listing`, `service-listing`, `portfolio-showcase`, `profile-listing`
+- **Seller/Community statuses:** `APPLIED`, `APPROVED`, `WAITLISTED`
+- **Brand membership:** `BASIC`, `TALENT_SUITE`
+- **Seller membership:** `BASIC`, `CONNECT`, `PRO`
+
+### Hosted configuration (Sharetribe Console)
+
+The app fetches live configuration from Sharetribe on every full-page load via `sdk.asset*`. These override local files in `src/config/`. The merge logic lives in `src/util/configHelpers.js` (`mergeConfig`). Access config in components via `useConfiguration()`.
+
+## TheLuupe-specific features
+
+### Digital product upload & download
+
+- **Upload:** Handled client-side via [Uppy](https://uppy.io/) + [Transloadit](https://transloadit.com/). The server endpoint `POST /api/transloadit-params` signs the upload parameters. The original file URL is stored in `listing.privateData.originalAssetUrl`; the original filename in `listing.publicData.originalFileName`.
+- **Download:** `POST /api/digital-product-download` — verifies the requesting user is the transaction's customer, checks transaction state is `PURCHASED`, `COMPLETED`, or `REVIEWED`, then generates a signed GCS URL (8-hour expiry) via `@google-cloud/storage`. Download filename is formatted as `TheLuupe_{listingId}{ext}`.
+
+### Phototag (AI keyword generation)
+
+`POST /api/phototag-keywords` — sends listing images to the Phototag AI API and returns up to 40 single-word keywords. Used from `BatchEditListingPage` for bulk keyword management.
+
+### Brand Studio system
+
+Managed via an internal **Studio Manager** microservice (`server/api-util/studioHelper.js`). Brand admins create studios, invite users via shareable links, and control membership. User metadata is synced between Auth0 app metadata and Sharetribe user `privateData`/`publicData`. The relevant fields: `studioId`, `communityId`, `userType`, `isBrandAdmin`, `brandStudioId`.
+
+### Auth0 / OAuth
+
+`server/api/auth/auth0.js` uses `express-openid-connect` (OIDC). Custom claims are namespaced as `ext-mp-*` in the JWT. On login, `createUserWithIdp.js` / `loginWithIdp.js` sync Auth0 app metadata into Sharetribe. Session cookie lifetime defaults to 7 days.
+
+### Slack integration
+
+`server/api-util/slackHelper/` posts Block Kit messages to two channels:
+- `SLACK_USER_MANAGER_CHANNEL_ID` — seller/community approvals
+- `SLACK_LISTING_MANAGER_CHANNEL_ID` — product listing reviews and errors
+
+Interactive button responses (approve/reject) are handled at `POST /api/slack/interactivity` with HMAC signature verification.
+
+### License deals
+
+Custom per-user price negotiated outside the platform. Stored in `listing.privateData.customLicenseDeals[]`. Validated server-side at `POST /api/validate-license-deal` before checkout.
+
+### Vouchers / discounts
+
+Powered by [Voucherify](https://voucherify.io/). `POST /api/validate-voucher` gets-or-creates a Voucherify customer, validates the code, and returns discount metadata. Only percentage discounts (`APPLY_TO_ORDER`) are supported.
+
+### Referral program
+
+Powered by [Referral Factory](https://referral-factory.com/). `POST /api/referral-manager` opts users in on first call and stores their referral code in `user.privateData.referralCode`. Qualification is recorded when a purchase is completed.
+
+### Event-driven scripts
+
+`server/api-util/scriptManager.js` polls the Sharetribe Integration API for events and dispatches them to scripts in `server/scripts/events/`. The integration SDK is a singleton with self-healing reconnect logic (up to 3 retries before forced reinit). These scripts handle: seller approval notifications, portfolio listing updates, brand user assignment.
+
+## Development best practices
+
+### Commit messages
+
+- Write commits in the **imperative mood**: "Add download endpoint" not "Added download endpoint".
+- Lead with *what* changed and *why*, not just the file name: `Fix voucher validation to reject expired codes` not `Update api/voucher.js`.
+- Scope the subject line to a single logical change. If you need "and" to describe it, split it into two commits.
+- Keep the subject line under 72 characters. Add a blank line before the body when more context is needed.
+- Reference ticket/issue numbers at the end of the body when relevant: `Closes #123`.
+
+### Following existing patterns
+
+- Before adding a new API endpoint, read two or three existing ones in `server/api/` to match the structure (auth middleware order, error handling, response shape).
+- Before adding a new page, read a similar `.duck.js` and page component to match the `loadData` / Redux / SSR pattern.
+- Reuse components from `src/components/` before writing new ones. Check the index barrel export first.
+- Name files consistently with their neighbors: page components are `PascalCasePage.js`, ducks are `PascalCasePage.duck.js`, CSS modules are `PascalCasePage.module.css`.
+- Keep new utilities in `src/util/` (frontend) or `server/api-util/` (backend). Do not scatter helper logic into page or component files.
+
+### Code quality
+
+- Run `yarn format` before committing to apply Prettier. CI will fail on formatting violations.
+- Run the relevant test suite (`yarn test-server` or `yarn test`) after touching shared utilities or transaction logic.
+- Never disable ESLint rules inline (`// eslint-disable`) without a comment explaining why.
+- Keep components focused: if a component file exceeds ~300 lines, consider extracting sub-components.
+- Remove dead code rather than commenting it out. Git history preserves it if it is ever needed again.
+- Avoid `console.log` in committed code; use the existing logger utilities or remove debug statements before opening a PR.
+
+## Code conventions (from AGENTS.md)
+
+- **Import order:** external libs → config/util → shared components (via `src/components/index.js`) → parent dir → same dir. Violating this causes circular dependency errors.
+- **Forms:** Always use React Final Form. Components prefixed `Field*` in `src/components/` are for RFF fields.
+- **Utilities:** Prefer local utilities in `src/util/` over new npm packages. Ask before adding a dependency.
+- **Redux:** Toolkit + Ducks pattern. Global ducks in `src/ducks/`; page-level ducks colocated with the page.
+- **Styling:** Mobile-first CSS Modules. Breakpoints: `--viewportMedium` (768px), `--viewportLarge` (1024px). 6px baseline below medium, 8px at medium+.
+- **i18n:** All copy must use `<FormattedMessage>` or `intl.formatMessage()`. New keys follow pattern `"ComponentName.key": "text"`.
+- **Prettier:** single quotes, 2 spaces, trailing commas, 100-char line limit.

--- a/TL_CHANGELOG.md
+++ b/TL_CHANGELOG.md
@@ -1,0 +1,123 @@
+# TheLuupe Marketplace — Custom Changelog
+
+This file tracks changes made to TheLuupe's fork of [Sharetribe Web Template](https://github.com/sharetribe/web-template). It only documents **TheLuupe-specific additions and modifications** — upstream Sharetribe changes are tracked in `CHANGELOG.md`.
+
+---
+
+## [Initial Custom Implementation] — Pre-2026
+
+> This entry consolidates all custom features present at the time this changelog was initialized (2026-04-07). Future changes should be logged as individual versioned entries.
+
+### New Features
+
+#### Digital Product Upload & Download
+- Integrated [Transloadit](https://transloadit.com/) for client-side file uploads. Server endpoint `POST /api/transloadit-params` signs upload parameters.
+- Integrated Google Cloud Storage for original asset hosting. Files stored with listing ID + original extension.
+- Added `POST /api/digital-product-download` — generates signed GCS download URLs (8-hour expiry) gated on transaction state (`PURCHASED`, `COMPLETED`, or `REVIEWED`). Download filename formatted as `TheLuupe_{listingId}{ext}`.
+- Listing stores `publicData.originalFileName` and `privateData.originalAssetUrl`.
+
+#### Phototag AI Keywords
+- Added `POST /api/phototag-keywords` — sends images to the [Phototag AI](https://phototag.ai/) API and returns up to 40 single-word keywords per image.
+- Supports exclusion lists (e.g. profile name) and development mock mode.
+- Added `BatchEditListingPage` for bulk keyword management across multiple listings.
+- Added upgrade scripts in `server/api/scripts-retry/upgradePhototagKeywords/`.
+
+#### Brand Studio System
+- Added `server/api-util/studioHelper.js` — client wrapper for internal Studio Manager microservice.
+- Brand admins can create studios, invite users via shareable links, and manage membership.
+- User types: `buyer`, `creative-seller`, `studio-brand`.
+- Brand membership tiers: `BASIC`, `TALENT_SUITE`. Seller membership tiers: `BASIC`, `CONNECT`, `PRO`.
+- User metadata (`studioId`, `communityId`, `userType`, `isBrandAdmin`, `brandStudioId`) synced between Auth0 and Sharetribe.
+- Added `BrandManagementPage` for studio admin UI.
+- Added retry script `server/api/scripts-retry/retryBrandUserAssignment.js`.
+
+#### Portfolio Listing Type
+- Added `portfolio-showcase` listing type (distinct from `product-listing`, `service-listing`, `profile-listing`).
+- Portfolio listings auto-transition from `pendingApproval` to `approved` state.
+- Added `EditPortfolioListingPage` with wizard UI supporting video/file panels.
+- Profile listings auto-created when sellers are approved.
+
+#### Auth0 / OAuth Integration
+- Added `server/api/auth/auth0.js` using `express-openid-connect` OIDC middleware.
+- Custom JWT claims namespaced as `ext-mp-*` carry marketplace-specific user metadata.
+- `createUserWithIdp.js` and `loginWithIdp.js` handle user creation/login via identity providers.
+- `server/api-util/auth0Helper.js` wraps the Auth0 Management API for metadata reads/writes.
+- Session cookie lifetime: 7 days (configurable).
+- Auth error state persisted via cookie for frontend error handling.
+
+#### Negotiation Transaction Process
+- Added `default-negotiation` transaction process with **forward** (customer-initiated) and **reverse** (provider-initiated) modes.
+- Supports: make-offer, request-quote, counter-offers from both parties, operator rejection.
+- Added `server/api-util/negotiation.js` for server-side offer validation and history consistency checks.
+- Added `MakeOfferPage` and `RequestQuotePage` for the respective negotiation entry points.
+- Offer history stored as metadata array on the transaction.
+
+#### `default-purchase-no-stripe` Transaction Process
+- Added an alternative purchase flow for deals where payment is handled outside the platform.
+
+#### License Deal Validation
+- Custom per-user pricing stored in `listing.privateData.customLicenseDeals[]`.
+- Added `POST /api/validate-license-deal` — verifies deal expiry, buyer authorization, and listing type eligibility before checkout.
+- License upgrade line item handled via `getLicenseUpgradeLineItem()` in `lineItemHelpers.js`.
+
+#### Voucher / Discount Codes
+- Integrated [Voucherify](https://voucherify.io/) for discount code management.
+- Added `POST /api/validate-voucher` — gets-or-creates a Voucherify customer, validates code, applies percentage discount to order.
+
+#### Referral Program
+- Integrated [Referral Factory](https://referral-factory.com/).
+- Added `POST /api/referral-manager` — auto-opts users in on first call, stores referral code in `user.privateData.referralCode`.
+- Qualification recorded on purchase completion.
+- Added `ReferralProgramPage`.
+
+#### Slack Notifications & Approvals
+- Added `server/api-util/slackHelper/` with Block Kit message builders.
+- Two Slack channels: user management (seller/community approvals) and listing management (product review, errors).
+- Interactive approval buttons (Approve/Reject) handled at `POST /api/slack/interactivity` with HMAC signature + timestamp verification.
+- Covers workflows: seller validation, community approval, product listing created, portfolio listing updated, user creation errors.
+
+#### Event-Driven Background Scripts
+- Added `server/api-util/scriptManager.js` — polls Sharetribe Integration API for events, dispatches to handlers in `server/scripts/events/`.
+- Self-healing SDK singleton with reconnect logic (up to 3 retries before forced reinit, 5-min poll timeout).
+- Event scripts: `notifyUserCreated`, `notifyProductListingCreated`, `notifyPortfolioListingUpdated`.
+
+### Modified Core Behavior
+
+#### User Account & Profile
+- Added `CreativeDetailsPage` for seller-specific profile information.
+- Added `ManageAccountPage` for extended account management.
+- Added account deletion flow (`DELETE /api/delete-account`).
+- Added seller/community status fields (`APPLIED`, `APPROVED`, `WAITLISTED`) to user metadata.
+
+#### Search
+- Added `FavoriteListingsPage` — users can save/unsave listings.
+- Search page supports both map (`SearchPageWithMap`) and grid (`SearchPageWithGrid`) variants, toggled via hosted config.
+
+#### Line Items & Pricing
+- Extended `server/api-util/lineItemHelpers.js` with: multi-item shipping calculations, voucher discount application, license deal upgrade line items, commission calculations (provider and customer).
+
+### Infrastructure & Tooling
+
+- Added `server/api-util/metadataHelper.js` — centralized enums for user types, listing types, statuses, and membership tiers.
+- Added `server/api-util/cache.js` and `server/api-util/sdkCacheProxy.js` — SDK response caching layer.
+- Added `server/api-util/retryAsync.js` — generic retry utility for async operations.
+- Added `scripts/audit.js` — custom yarn audit parser.
+- Added `scripts/translations.js` — translation management helper.
+- Added `version:patch` npm script using `prerelease` with `theluuupe` preid.
+- Node engine requirement: `>=22.22.0` (`.nvmrc`: `24.13.0`).
+- Dockerfile and `cloudbuild.yaml` for GCP-based CI/CD.
+- `.circleci/` configuration for CI pipeline.
+
+---
+
+## How to add entries
+
+When implementing a new feature or change, add an entry at the top of this file:
+
+```markdown
+## [Short Description] — YYYY-MM-DD
+
+### Added / Changed / Fixed / Removed
+
+- Description of what changed and why. Reference relevant files.
+```

--- a/TL_README.md
+++ b/TL_README.md
@@ -1,0 +1,264 @@
+# TheLuupe Marketplace — Custom Implementation Guide
+
+This document covers TheLuupe-specific systems and integrations that are **not part of the upstream Sharetribe Web Template**. For general template documentation, see `README.md` and `AGENTS.md`.
+
+---
+
+## Digital Product Upload & Download
+
+This is the core e-commerce mechanic for TheLuupe — sellers upload original files (photos, videos) and buyers download them after purchasing.
+
+### Upload flow
+
+1. Seller uploads a file through the listing edit UI via [Uppy](https://uppy.io/).
+2. Uppy calls `POST /api/transloadit-params` to get a signed Transloadit signature.
+3. Transloadit processes and stores the file in Google Cloud Storage.
+4. Two pieces of metadata are saved to the listing:
+   - `listing.publicData.originalFileName` — the original filename (shown to buyer)
+   - `listing.privateData.originalAssetUrl` — the GCS URL (never exposed to frontend directly)
+
+### Download flow
+
+1. After a successful purchase, the buyer triggers `POST /api/digital-product-download` with the `transactionId`.
+2. The server:
+   - Confirms the requesting user is the transaction's `customer`
+   - Checks transaction state is `PURCHASED`, `COMPLETED`, or `REVIEWED` (via the process graph)
+   - Generates a **signed GCS URL** with 8-hour expiry using `@google-cloud/storage`
+3. The download filename is formatted as `TheLuupe_{listingId}{originalExtension}`.
+
+**Key file:** `server/api/digital-product-download.js`
+
+### Required environment variables
+
+```
+GOOGLE_APPLICATION_CREDENTIALS   # Path to GCS service account JSON
+TRANSLOADIT_KEY                  # Transloadit API key
+TRANSLOADIT_SECRET               # Transloadit API secret
+TRANSLOADIT_TEMPLATE_ID          # Transloadit template ID for uploads
+```
+
+---
+
+## Phototag — AI Keyword Generation
+
+Sellers can auto-generate SEO keywords for their listings using the Phototag AI service.
+
+- **Endpoint:** `POST /api/phototag-keywords`
+- **Input:** Array of image URLs from the listing
+- **Output:** Up to 40 single-word keywords
+- **Used from:** `BatchEditListingPage` (bulk) and listing edit flow
+
+The service supports an exclusion list (e.g. the seller's name) to avoid generic or identifying keywords. In development, set `PHOTOTAG_API_URL` to a mock endpoint.
+
+### Required environment variables
+
+```
+PHOTOTAG_API_URL        # Defaults to https://server.phototag.ai/api/keywords
+PHOTOTAG_BEARER_TOKEN   # Bearer token for Phototag API
+```
+
+---
+
+## Brand Studio System
+
+Agencies and multi-photographer studios operate under a shared brand identity.
+
+### User roles
+
+- **Brand Admin** — creates/manages the studio, invites members. Identified by `user.publicData.isBrandAdmin = true`.
+- **Brand User** — member of a studio. Identified by `user.publicData.userType = 'studio-brand'` and a `brandStudioId`.
+
+### How it works
+
+1. A brand admin creates a studio via the Studio Manager microservice (internal service at `WEBAPI_URL/api/v1/management`).
+2. Invite links are generated containing a `brand-studio-id` parameter.
+3. When a new user registers via that link, Auth0 app metadata carries `brandStudioId` and `userType`.
+4. On user creation, `server/scripts/events/notifyUserCreated.js` syncs this metadata to Sharetribe user `privateData`/`publicData`.
+
+### Key files
+
+- `server/api-util/studioHelper.js` — Studio Manager API client
+- `server/api-util/auth0Helper.js` — Auth0 Management API client
+- `server/scripts/events/notifyUserCreated.js` — handles new user event
+- `server/api/scripts-retry/retryBrandUserAssignment.js` — retry on assignment failure
+
+### Required environment variables
+
+```
+WEBAPI_URL                    # Internal Studio Manager service base URL
+STUDIO_MANAGER_API_KEY        # Auth header for Studio Manager
+AUTH0_DOMAIN                  # Auth0 tenant domain
+AUTH0_MGMT_CLIENT_ID          # Auth0 Management API client ID
+AUTH0_MGMT_CLIENT_SECRET      # Auth0 Management API client secret
+```
+
+---
+
+## Auth0 / OAuth
+
+Authentication uses Auth0 as the OIDC provider via `express-openid-connect`.
+
+### Custom JWT claims
+
+Auth0 adds marketplace-specific claims namespaced as `ext-mp-*`:
+- `ext-mp-user-type` — `buyer` | `creative-seller` | `studio-brand`
+- `ext-mp-studio-id`
+- `ext-mp-community-id`
+- `ext-mp-is-brand-admin`
+- `ext-mp-brand-studio-id`
+
+These are read in `server/api/auth/createUserWithIdp.js` and `loginWithIdp.js` to sync data into Sharetribe.
+
+### Required environment variables
+
+```
+AUTH0_DOMAIN          # e.g. your-tenant.auth0.com
+AUTH0_CLIENT_ID
+AUTH0_CLIENT_SECRET
+AUTH0_CALLBACK_URL    # Must match Auth0 app settings
+```
+
+---
+
+## Negotiation Transaction Process
+
+The `default-negotiation` process supports price negotiation before checkout.
+
+### Two modes
+
+| Mode | Who creates the listing | Who initiates |
+|---|---|---|
+| **Forward** | Provider (seller) | Customer sends a `request-quote` |
+| **Reverse** | Customer (buyer posts a request) | Provider sends a `make-offer` |
+
+Mode is set on `listing.publicData.negotiationMode`. The frontend checks this to show the correct initial action button.
+
+### Counter-offer loop
+
+Both parties can counter-offer. All offers are stored as an array in `transaction.metadata.offers`, with timestamps and actor IDs. Server-side validation in `server/api-util/negotiation.js` ensures offer history is consistent with the transition history.
+
+### Key files
+
+- `src/transactions/transactionProcessNegotiation.js` — frontend state graph
+- `server/api-util/negotiation.js` — server-side validation
+- `server/api-util/transactions/` — server-side process definitions
+
+> **Note:** Any change to the negotiation flow requires a matching update to the Sharetribe backend transaction process via Console or Integration API.
+
+---
+
+## Slack Integration
+
+Used for operator workflows: approving sellers and reviewing new listings.
+
+### Channels
+
+| Channel env var | Purpose |
+|---|---|
+| `SLACK_USER_MANAGER_CHANNEL_ID` | Seller applications, community approvals |
+| `SLACK_LISTING_MANAGER_CHANNEL_ID` | New product listings, errors |
+
+### Interactive approvals
+
+Slack sends `POST /api/slack/interactivity` when an operator clicks Approve/Reject. Requests are verified with HMAC-SHA256 signature + 5-minute timestamp window.
+
+Actions available: `approve_seller`, `reject_seller`, `approve_community`, `reject_community`.
+
+### Required environment variables
+
+```
+SLACK_BOT_TOKEN                   # xoxb-... token
+SLACK_SIGNING_SECRET              # For verifying interactive payloads
+SLACK_USER_MANAGER_CHANNEL_ID
+SLACK_LISTING_MANAGER_CHANNEL_ID
+```
+
+---
+
+## Voucher / Discount Codes (Voucherify)
+
+Discount codes are validated via [Voucherify](https://voucherify.io/) before checkout.
+
+- Only **percentage discounts** applied to the **entire order** are supported.
+- A Voucherify customer record is auto-created on first validation, linked to the Sharetribe user's email.
+- Endpoint: `POST /api/validate-voucher`
+
+### Required environment variables
+
+```
+VOUCHERIFY_APP_ID
+VOUCHERIFY_SECRET_KEY
+```
+
+---
+
+## Referral Program (Referral Factory)
+
+Users are auto-enrolled in the referral program via [Referral Factory](https://referral-factory.com/).
+
+- Referral code stored in `user.privateData.referralCode` after first opt-in.
+- Qualification (conversion) is recorded when a purchase completes.
+- Endpoint: `POST /api/referral-manager`
+
+### Required environment variables
+
+```
+REFERRAL_FACTORY_API_KEY
+REFERRAL_CAMPAIGN_ID
+```
+
+---
+
+## Event-Driven Scripts
+
+`server/api-util/scriptManager.js` runs a long-polling loop against the Sharetribe Integration API, processing events in batches of 10. It self-heals if the SDK goes idle (3 retries before forced reinit).
+
+### Registered event handlers (`server/scripts/events/`)
+
+| Script | Trigger |
+|---|---|
+| `notifyUserCreated.js` | New user registered — syncs brand/studio metadata |
+| `notifyProductListingCreated.js` | New product listing — posts to Slack for review |
+| `notifyPortfolioListingUpdated.js` | Portfolio listing updated — posts error/update to Slack |
+
+### Required environment variables
+
+```
+SHARETRIBE_INTEGRATION_CLIENT_ID
+SHARETRIBE_INTEGRATION_CLIENT_SECRET
+```
+
+---
+
+## License Deals
+
+Custom per-user pricing for specific buyers, stored server-side.
+
+- Deals stored in `listing.privateData.customLicenseDeals[]` (array, one per buyer).
+- Each deal: `{ id, buyerId, customPrice, customTerms, generatedAt, expiresAt }`
+- Validated before checkout at `POST /api/validate-license-deal`.
+- Validation checks: listing is published, deal belongs to current user, deal is not expired, listing type is `product-listing` or `hidden-product-listing`.
+
+---
+
+## Listing Types Reference
+
+| Value | Description |
+|---|---|
+| `product-listing` | Standard digital asset for sale |
+| `hidden-product-listing` | Product not shown in public search |
+| `service-listing` | Service offering (booking/inquiry) |
+| `portfolio-showcase` | Creator portfolio (auto-approved, not transactable directly) |
+| `profile-listing` | Auto-created when a seller is approved |
+
+---
+
+## User Type Reference
+
+| Value | Description |
+|---|---|
+| `buyer` | Default for new registrations |
+| `creative-seller` | Approved seller/photographer |
+| `studio-brand` | Member of a brand studio |
+
+Seller and community approval status (`APPLIED`, `APPROVED`, `WAITLISTED`) is stored separately in `user.publicData.sellerStatus` and `user.publicData.communityStatus`.

--- a/server/api/scripts-retry/index.js
+++ b/server/api/scripts-retry/index.js
@@ -4,6 +4,7 @@ const retryUserCreated = require('./retryUserCreated');
 const upgradePhototagKeywordsScript = require('./upgradePhototagKeywords/index');
 const normalizeKeywordsScript = require('./normalizeKeywords/index');
 const sanitizeListingDataScript = require('./sanitizeListingData/index');
+const migratePortfolioOrderScript = require('./migratePortfolioOrder/index');
 
 module.exports = {
   ...retryBrandUserAssignment,
@@ -12,4 +13,5 @@ module.exports = {
   ...upgradePhototagKeywordsScript,
   ...normalizeKeywordsScript,
   ...sanitizeListingDataScript,
+  ...migratePortfolioOrderScript,
 };

--- a/server/api/scripts-retry/migratePortfolioOrder/index.js
+++ b/server/api/scripts-retry/migratePortfolioOrder/index.js
@@ -1,0 +1,187 @@
+const { integrationSdkInit } = require('../../../api-util/scriptManager');
+
+const ALLOWED_STATES = ['published', 'pendingApproval', 'closed', 'draft'];
+const LISTING_TYPE = 'portfolio-showcase';
+const QUERY_PARAMS = { expand: true };
+const LISTINGS_PER_PAGE = 100;
+
+const BASE_QUERY_PARAMS = {
+  states: ALLOWED_STATES,
+  pub_listingType: LISTING_TYPE,
+};
+
+async function processListingsPage({ listings, currentPage, totalPages }) {
+  if (!listings.length) {
+    console.info(`[migratePortfolioOrder] Page ${currentPage}/${totalPages} empty, stopping.`);
+    return { processed: 0, updated: 0, skipped: 0 };
+  }
+  let processedCount = 0;
+  let updatedCount = 0;
+  let skippedCount = 0;
+  for (const listingResource of listings) {
+    try {
+      const listingId = listingResource?.id?.uuid;
+      const privateOrder = listingResource?.attributes?.privateData?.order;
+      const publicOrder = listingResource?.attributes?.publicData?.order;
+      const hasPrivateOrder = privateOrder != null;
+      const hasPublicOrder = publicOrder != null;
+
+      // Skip listings that already have publicData.order set and no stale privateData.order.
+      if (!hasPrivateOrder && hasPublicOrder) {
+        skippedCount++;
+        processedCount++;
+        continue;
+      }
+      // Nothing to migrate for listings that never had an order set.
+      if (!hasPrivateOrder && !hasPublicOrder) {
+        skippedCount++;
+        processedCount++;
+        continue;
+      }
+
+      const integrationSdk = integrationSdkInit();
+      const updateData = {
+        id: listingId,
+        privateData: { order: null },
+      };
+      // Do not overwrite an existing publicData.order value if one is already present.
+      if (!hasPublicOrder) {
+        updateData.publicData = { order: privateOrder };
+      }
+      await integrationSdk.listings.update(updateData);
+      updatedCount++;
+      processedCount++;
+      console.info(
+        `+ [migratePortfolioOrder] Updated listing ${listingId}. ` +
+          `privateData.order: ${privateOrder} -> publicData.order: ${
+            hasPublicOrder ? publicOrder : privateOrder
+          }`
+      );
+    } catch (error) {
+      console.error(
+        `[migratePortfolioOrder] Failed to process listing ${listingResource?.id?.uuid}:`,
+        error
+      );
+      processedCount++;
+    }
+  }
+  const lastListing = listings[listings.length - 1];
+  const lastCreatedAt = lastListing?.attributes?.createdAt;
+  const lastCreatedAtISO = lastCreatedAt ? lastCreatedAt.toISOString() : 'N/A';
+  console.info(
+    `[migratePortfolioOrder] Processed page ${currentPage}/${totalPages}. ` +
+      `Processed: ${processedCount}, Updated: ${updatedCount}, Skipped: ${skippedCount}. ` +
+      `Last listing createdAt: ${lastCreatedAtISO}`
+  );
+  return { processed: processedCount, updated: updatedCount, skipped: skippedCount };
+}
+
+async function processListingsByQuery() {
+  let page = 1;
+  let totalPages = 1;
+  let totalProcessed = 0;
+  let totalUpdated = 0;
+  let totalSkipped = 0;
+  do {
+    try {
+      const integrationSdk = integrationSdkInit();
+      const response = await integrationSdk.listings.query(
+        {
+          page,
+          perPage: LISTINGS_PER_PAGE,
+          sort: 'createdAt',
+          ...BASE_QUERY_PARAMS,
+        },
+        QUERY_PARAMS
+      );
+      const { data, meta = {} } = response?.data || {};
+      const listings = data || [];
+      totalPages = meta?.totalPages || page;
+      if (page === 1) {
+        console.info('\n\n\n*******************************');
+        console.info(
+          `[migratePortfolioOrder] Starting migration. ` +
+            `Total listings: ${meta?.totalItems ?? 'unknown'}, ` +
+            `Total pages: ${totalPages} (perPage: ${LISTINGS_PER_PAGE})`
+        );
+      }
+      const pageStats = await processListingsPage({
+        listings,
+        currentPage: page,
+        totalPages,
+      });
+      totalProcessed += pageStats.processed;
+      totalUpdated += pageStats.updated;
+      totalSkipped += pageStats.skipped;
+      const hasMore = page < totalPages && listings.length > 0;
+      console.info(
+        `[migratePortfolioOrder] Total stats: Processed: ${totalProcessed}, ` +
+          `Updated: ${totalUpdated}, Skipped: ${totalSkipped}`
+      );
+      if (!hasMore) {
+        break;
+      }
+      page += 1;
+    } catch (error) {
+      console.error(`[migratePortfolioOrder] Failed processing listings page ${page}:`, error);
+      break;
+    }
+  } while (page <= totalPages);
+  console.info(
+    `[migratePortfolioOrder] Script completed. Total: Processed: ${totalProcessed}, ` +
+      `Updated: ${totalUpdated}, Skipped: ${totalSkipped}`
+  );
+  console.info('*******************************\n\n\n');
+}
+
+async function processSingleListingById(listingId) {
+  try {
+    const integrationSdk = integrationSdkInit();
+    const response = await integrationSdk.listings.query(
+      {
+        ids: [listingId],
+        ...BASE_QUERY_PARAMS,
+      },
+      QUERY_PARAMS
+    );
+    const listings = response?.data?.data;
+    if (!listings || listings.length === 0) {
+      console.warn(`[migratePortfolioOrder] Listing ${listingId} not found.`);
+      return;
+    }
+    await processListingsPage({
+      listings,
+      currentPage: 1,
+      totalPages: 1,
+    });
+  } catch (error) {
+    console.error(`[migratePortfolioOrder] Failed processing listing ${listingId}:`, error);
+  }
+}
+
+async function runMigratePortfolioOrder({ listingId }) {
+  if (listingId) {
+    await processSingleListingById(listingId);
+  } else {
+    await processListingsByQuery();
+  }
+}
+
+const migratePortfolioOrderScript = (req, res) => {
+  const { listingId = null } = req.params;
+  if (listingId && typeof listingId !== 'string') {
+    return res.status(400).json({ error: 'invalidListingId' });
+  }
+  res.status(200).json({
+    accepted: true,
+    listingId: listingId || null,
+    message: 'Migrate portfolio order script started',
+  });
+  runMigratePortfolioOrder({ listingId }).catch(error => {
+    console.error('[migratePortfolioOrder] Unexpected error during processing:', error);
+  });
+};
+
+module.exports = {
+  migratePortfolioOrderScript,
+};

--- a/server/apiRouter.js
+++ b/server/apiRouter.js
@@ -41,6 +41,7 @@ const {
   upgradePhototagKeywordsScript,
   normalizeKeywordsScript,
   sanitizeListingDataScript,
+  migratePortfolioOrderScript,
 } = require('./api/scripts-retry');
 const transitionPrivileged = require('./api/transition-privileged');
 const transloaditParams = require('./api/transloadit-params');
@@ -122,6 +123,7 @@ if (useDevApiServer) {
   router.get('/scrips-retry/upgrade-phototag-keywords{/:listingId}', upgradePhototagKeywordsScript);
   router.get('/scrips-retry/normalize-keywords{/:listingId}', normalizeKeywordsScript);
   router.get('/scrips-retry/sanitize-listing-data{/:listingId}', sanitizeListingDataScript);
+  router.get('/scrips-retry/migrate-portfolio-order{/:listingId}', migratePortfolioOrderScript);
 }
 
 // Create user with identity provider (e.g. Facebook or Google)

--- a/src/containers/EditPortfolioListingPage/EditPortfolioListingPage.duck.js
+++ b/src/containers/EditPortfolioListingPage/EditPortfolioListingPage.duck.js
@@ -316,8 +316,11 @@ export const savePortfolioListingsOrder = orderedIds => async (dispatch, getStat
       orderedIds.map((id, index) => {
         return sdk.ownListings.update({
           id,
-          privateData: {
+          publicData: {
             order: index + 1,
+          },
+          privateData: {
+            order: null,
           },
         });
       })

--- a/src/containers/ManageListingsPage/utils.js
+++ b/src/containers/ManageListingsPage/utils.js
@@ -30,7 +30,7 @@ export const getLinks = (listings, currentListingType) => {
         name: 'ManageListingsPage',
         displayText: listing.attributes.title,
         to: { search: getSearch(listing.id.uuid, currentListingType) },
-        order: listing.attributes.privateData?.order,
+        order: listing.attributes.publicData?.order ?? listing.attributes.privateData?.order,
       }));
     }
     case LISTING_TAB_TYPES.PRODUCT:

--- a/src/containers/ProfilePage/utils.js
+++ b/src/containers/ProfilePage/utils.js
@@ -51,13 +51,16 @@ export const getLinks = (userId, listings, currentListingType, reviewTabsLabels)
       return [];
     }
     case LISTING_TAB_TYPES.PORTFOLIO: {
-      return listings.map(listing => ({
-        id: listing.id.uuid,
-        name: 'ProfilePage',
-        displayText: listing.attributes.title,
-        to: { search: getSearch(listing.id.uuid, currentListingType) },
-        params: { id: userId },
-      }));
+      return listings
+        .map(listing => ({
+          id: listing.id.uuid,
+          name: 'ProfilePage',
+          displayText: listing.attributes.title,
+          to: { search: getSearch(listing.id.uuid, currentListingType) },
+          params: { id: userId },
+          order: listing.attributes.publicData?.order,
+        }))
+        .sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity));
     }
     case LISTING_TAB_TYPES.PRODUCT:
     default: {


### PR DESCRIPTION
Move portfolio sort order from privateData to publicData

The order of a creator's portfolio items was persisted on
listing.privateData.order, which the Sharetribe public listings API
does not expose. As a result, the manual drag-to-reorder done from
ManageListingsPage was invisible on the public ProfilePage, where
portfolio tabs rendered in API default order instead of the creator's
chosen sequence.

- Write path: savePortfolioListingsOrder now writes publicData.order
  and clears privateData.order on each reorder.
- Read path: ManageListingsPage keeps a publicData.order ?? privateData.order
  fallback while the backfill runs.
- Public profile: ProfilePage getLinks sorts portfolio tabs by
  publicData.order client-side (listings without an order sink to the
  end via an Infinity fallback), since ScrollableLinks skips its own
  sortLinks when sortable=false.
- Backfill: new dev-only migratePortfolioOrder script copies
  privateData.order -> publicData.order for every portfolio-showcase
  listing via the Integration SDK, exposed at
  GET /api/scrips-retry/migrate-portfolio-order{/:listingId}.
