### PR TITLE
Restore creatives Location filter on SRP

### DIFF
--- a/spec/upstream-merge-v10.14-to-v11.0.2.md
+++ b/spec/upstream-merge-v10.14-to-v11.0.2.md
@@ -819,6 +819,35 @@ Verification: run `yarn config-check`, then load the search and
 edit-listing pages with each TheLuupe listing type after the merge.
 Watch for "filtered out" warnings in the console.
 
+**Confirmed in-merge silent-risk fix**: `src/containers/SearchPage/SearchPageWithGrid.js`'s
+`creativesLocationField` (the augmented "location" filter shown on
+`/s?pub_categoryLevel1=creatives` for `profile-listing`) declared
+`filterConfig: { indexForSearch: true, group: 'primary' }` only. Pre-merge,
+`groupListingFieldConfigs` gated visibility on
+`filterConfig?.indexForSearch === true`. Upstream rewrote that gate to use
+`isFilterEnabled(filterConfig)` (in `src/util/search.js`), which **only**
+checks `showFilter === true` — the function's doc comment claims a
+fallback to `indexForSearch` but the implementation does not. Result: the
+creatives location filter silently disappeared from the SRP. **Fix**: add
+`showFilter: true` alongside the existing `indexForSearch: true` in the
+field's `filterConfig`. Any future TheLuupe listing field that wants to
+be both indexed and visible needs both keys.
+
+**Confirmed in-merge silent-risk fix**: `src/containers/SearchPage/SearchPage.shared.js`'s
+new shared `createFilterValueChangeHandler` (which replaced
+TheLuupe HEAD's per-page `getHandleChangedValueFn`) regressed the
+address/bounds handling. Pre-merge, the keyword-search branch was
+`keywordsMaybe = { keywords }` and address/bounds were only re-spread
+from the URL in the location-search branch (`{ address, bounds }`).
+Upstream's rewrite always re-spreads `address, bounds` at the bottom of
+the merged-query-params object — clobbering whatever the sidebar
+LocationFilter put into `updatedURLParams`. Result: selecting a location
+in the creatives LocationFilter became a no-op (URL never updated).
+Upstream never hit this because they don't render a LocationFilter inside
+keyword-search mode. **Fix**: restore the pre-merge conditional
+(`isMainSearchTypeKeywords(config) ? { keywords } : { address, bounds }`)
+and drop the always-spread `address, bounds` at the bottom.
+
 ### 4.4 `ext/transaction-processes/default-negotiation/templates/.../*-html.html` (post-merge action)
 
 PR #837 renamed an i18n key in one negotiation email:

--- a/src/containers/SearchPage/SearchPage.shared.js
+++ b/src/containers/SearchPage/SearchPage.shared.js
@@ -835,7 +835,14 @@ export const createFilterValueChangeHandler = (
       const { address, bounds, keywords } = urlQueryParams;
       const mergedQueryParams = { ...urlQueryParams, ...prevState.currentQueryParams };
 
-      const keywordsMaybe = isMainSearchTypeKeywords(config) ? { keywords } : {};
+      // TheLuupe: address/bounds are owned by the TopbarSearchForm / map
+      // controls in location-search mode, so re-spread them from the URL
+      // there. In keyword-search mode they are owned by the sidebar
+      // LocationFilter (creatives category), so they must come from
+      // `updatedURLParams` instead — re-spreading from the URL would clobber
+      // the filter's selection. Pre-merge SearchPageWithGrid behaved this
+      // way; upstream's shared handler regressed by always re-spreading.
+      const keywordsMaybe = isMainSearchTypeKeywords(config) ? { keywords } : { address, bounds };
 
       const datesAndSeatsMaybe = getDatesAndSeatsMaybe(mergedQueryParams, updatedURLParams);
 
@@ -846,8 +853,6 @@ export const createFilterValueChangeHandler = (
             ...updatedURLParams,
             ...keywordsMaybe,
             ...datesAndSeatsMaybe,
-            address,
-            bounds,
           },
           filterConfigs
         ),

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -56,6 +56,7 @@ const buildAugmentedConfig = config => {
     schemaType: 'location',
     filterConfig: {
       indexForSearch: true,
+      showFilter: true,
       group: 'primary',
     },
     categoryConfig: {


### PR DESCRIPTION
Two upstream regressions that only manifest on TheLuupe because we augment the keyword-search SRP with a sidebar LocationFilter (creatives
+ profile-listing) — upstream never does, so they didn't notice.

- SearchPageWithGrid.js (creativesLocationField): upstream split the one-knob "indexForSearch" into two (indexForSearch = backend index, showFilter = UI visibility) and rewrote groupListingFieldConfigs to gate visibility on isFilterEnabled(), which only checks showFilter === true (the doc comment claims a fallback to indexForSearch but the implementation does not). Add showFilter: true so the filter renders.

- SearchPage.shared.js (createFilterValueChangeHandler): upstream's shared handler always re-spreads address/bounds from the URL at the bottom of the merged query params, clobbering whatever updatedURLParams (i.e. LocationFilter's selection) just set. Restore the pre-merge conditional — only re-spread in location-search mode; in keyword-search mode let updatedURLParams win.

- Spec §4.3 updated with both silent-risk notes so future fields/merges know the new knobs and the handler's address/bounds ownership rule.